### PR TITLE
Introduce onlyIf to repoPackage and copyToBin

### DIFF
--- a/src/main/kotlin/org/tribot/wastedbro/gradle/plugin/TribotPlugin.kt
+++ b/src/main/kotlin/org/tribot/wastedbro/gradle/plugin/TribotPlugin.kt
@@ -28,8 +28,7 @@ class TribotPlugin : Plugin<Project> {
             task.onlyIf {
                 project.tasks
                     .filter { it.name == "compileJava" || it.name == "compileKotlin" }
-                    .map { it.didWork }
-                    .any { it }
+                    .any { it.didWork }
             }
 
             task.doLast {
@@ -74,8 +73,7 @@ class TribotPlugin : Plugin<Project> {
             task.onlyIf {
                 project.tasks
                     .filter { it.name == "compileJava" || it.name == "compileKotlin" }
-                    .map { it.didWork }
-                    .any { it }
+                    .any { it.didWork }
             }
 
             task.doLast {

--- a/src/main/kotlin/org/tribot/wastedbro/gradle/plugin/TribotPlugin.kt
+++ b/src/main/kotlin/org/tribot/wastedbro/gradle/plugin/TribotPlugin.kt
@@ -24,6 +24,14 @@ class TribotPlugin : Plugin<Project> {
 
         project.tasks.create("repoPackage") { task ->
             task.group = "tribot"
+
+            task.onlyIf {
+                project.tasks
+                    .filter { it.name == "compileJava" || it.name == "compileKotlin" }
+                    .map { it.didWork }
+                    .any { it }
+            }
+
             task.doLast {
 
                 val projectDir = project.projectDir
@@ -62,6 +70,14 @@ class TribotPlugin : Plugin<Project> {
 
         project.tasks.create("copyToBin") { task ->
             task.group = "tribot"
+
+            task.onlyIf {
+                project.tasks
+                    .filter { it.name == "compileJava" || it.name == "compileKotlin" }
+                    .map { it.didWork }
+                    .any { it }
+            }
+
             task.doLast {
 
                 val projectDir = project.projectDir


### PR DESCRIPTION
Builds with a lot of projects were getting too long, or too expensive (with parallel enabled)